### PR TITLE
Test script for validating XML and badge in the README

### DIFF
--- a/.github/workflows/validate-xml.yml
+++ b/.github/workflows/validate-xml.yml
@@ -1,0 +1,28 @@
+name: Validate TEI XML
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install xmlint
+        run: sudo apt-get install -y libxml2-utils
+
+      - name: Run validation script
+        run: ./tests/test_valid_xml.sh
+
+      - name: Commit badge if changed
+        run: |
+          git config --global user.name "GitHub Action"
+          git config --global user.email "action@github.com"
+          git add tests/xml_validation_badge.svg
+          git diff --cached --quiet || git commit -m "Update XML validation badge"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coptic Scriptorium - Corpora
 
+![XML Validation](./tests/xml_validation_badge.svg)
+
 This is the public repository for Coptic SCRIPTORIUM corpora.  The documents are available in multiple formats: CoNLL-U, relANNIS, PAULA XML, TEI XML, and TreeTagger SGML (`*.tt`). The `*.tt` files generally contain the most complete representations of document annotations, though note that corpus level metadata is only included in the PAULA XML and relANNIS versions.
 
 Corpora can be searched, viewed, and queried with complex queries http://data.copticscriptorium.org.  Project homepage is http://copticscriptorium.org

--- a/tests/tei_validation_badge.svg
+++ b/tests/tei_validation_badge.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+    <stop offset="1" stop-opacity=".7"/>
+  </linearGradient>
+  <rect rx="3" width="150" height="20" fill="#555"/>
+  <rect rx="3" x="70" width="80" height="20" fill=""/>
+  <path fill="" d="M70 0h4v20h-4z"/>
+  <rect rx="3" width="150" height="20" fill="url(#s)"/>
+  <g fill="#fff" text-anchor="middle"
+     font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="35" y="14">validation</text>
+    <text x="110" y="14">95%</text>
+  </g>
+</svg>

--- a/tests/test_valid_xml.sh
+++ b/tests/test_valid_xml.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Get the directory of the current script
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Get the parent directory of the script directory
+BASE_DIR="$(dirname "$TEST_DIR")"
+
+# Initialize counters
+total=0
+valid=0
+
+# Loop over XML files
+for file in $(find $BASE_DIR -name '*.xml'); do
+    if [ -f "$file" ]; then
+        ((total++))
+        
+        # TODO Use the TEI schema to validate the XML file
+        # if xmllint --noout --schema "$SCHEMA" "$file" 2>/dev/null; then
+        
+        # Validate using xmllint
+        if xmllint --noout "$file" 2>/dev/null; then
+            ((valid++))
+        else
+            echo "$file: invalid"
+        fi
+    fi
+done
+
+# Calculate and print the percentage of valid files
+if [ $total -eq 0 ]; then
+    echo "No XML files found."
+else
+    percentage=$((100 * valid / total))
+    echo "Valid XML files: $valid/$total ($percentage%)"
+fi
+
+# Set badge color based on percentage
+if [ $percentage -ge 99 ]; then
+    color="#4c1"  # green
+elif [ $percentage -ge 90 ]; then
+    color="#dfb317"  # yellow
+else
+    color="#e05d44"  # red
+fi
+
+# Define label and message
+label="XML Valid"
+message="${percentage}%"
+
+# Calculate dynamic widths
+label_width=70
+message_width=$(( ${#message} * 7 + 20 )) # dynamic width based on text length
+total_width=$((label_width + message_width))
+
+# Generate the badge SVG
+cat <<EOF > "$TEST_DIR/xml_validation_badge.svg"
+<svg xmlns="http://www.w3.org/2000/svg" width="$total_width" height="20" role="img" aria-label="$label: $message">
+  <title>$label: $message</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="$total_width" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="$label_width" height="20" fill="#555"/>
+    <rect x="$label_width" width="$message_width" height="20" fill="$color"/>
+    <rect width="$total_width" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" text-rendering="geometricPrecision" font-size="11">
+    <text x="$((label_width / 2))" y="14">$label</text>
+    <text x="$((label_width + message_width / 2))" y="14">$message</text>
+  </g>
+</svg>
+EOF

--- a/tests/xml_validation_badge.svg
+++ b/tests/xml_validation_badge.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="XML Valid: 95%">
+  <title>XML Valid: 95%</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="111" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="70" height="20" fill="#555"/>
+    <rect x="70" width="41" height="20" fill="#dfb317"/>
+    <rect width="111" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" text-rendering="geometricPrecision" font-size="11">
+    <text x="35" y="14">XML Valid</text>
+    <text x="90" y="14">95%</text>
+  </g>
+</svg>


### PR DESCRIPTION
In issue #130 I mentioned that there were XML files that are not valid. I've created a script to count the valid ones:
`./tests/test_valid_xml.sh`

This creates an SVG badge showing the percentage of valid XML files
`tests/xml_validation_badge.svg`
This badge is displayed in the README

I've added a GitHub Actions workflow to run the script every push to master and it updates the badge.

At the moment, I'm only validating whether it is proper XML. Later on, we can add something else to determine if the XML is valid TEI.